### PR TITLE
printk semihosting only

### DIFF
--- a/drivers/semihosting.c
+++ b/drivers/semihosting.c
@@ -28,6 +28,11 @@ u32 smhost_open(const char* fname, u32 fname_size, u32 mode)
     return smhost_gateway(SMHOST_OPEN, smhost_req);
 }
 
+u32 smhost_putc(char value)
+{
+    return smhost_gateway(SMHOST_WRITEC, (void*)&value);
+}
+
 u32 smhost_print(const char* buf, u32 size)
 {
     u32 smhost_req[3] = {

--- a/include/drivers/semihosting.h
+++ b/include/drivers/semihosting.h
@@ -6,11 +6,13 @@ enum {
     SMHOST_OPEN   = 0x01,
     SMHOST_WRITE  = 0x05,
     SMHOST_WRITE0 = 0x04,
+    SMHOST_WRITEC = 0x03,
     SMHOST_W      = 0x4
 };
 
 extern int smhost_stdout;
 
+u32 smhost_putc(char value);
 u32 smhost_print(const char* buf, u32 size);
 u32 smhost_printz(const char* buf);
 

--- a/kernel/printk.c
+++ b/kernel/printk.c
@@ -78,14 +78,6 @@ size_t bprintptr(char* buf, void* ptr)
     return bytes + bprintu32(buf + bytes, (u32) ptr, 16);
 }
 
-void printu32(u32 a)
-{
-    char buf[MAX_LEN_U32 + 1];
-    size_t bytes = bprintu32(buf, a, 10);
-    buf[bytes] = '\0';
-    log_buffer_put(buf);
-}
-
 void printk(const char* fmt, ...)
 {
     const char* cursor = fmt;
@@ -95,7 +87,7 @@ void printk(const char* fmt, ...)
     s32 s32value;
     void* ptrvalue;
     char* str;
-    char buf[PRINTK_BUFFER_SIZE];
+    char buf[PRINTK_BUF_SIZE];
     size_t size;
 
     va_start(args, fmt);


### PR DESCRIPTION
printk now uses only semihosting `smhost_putc` and `smhost_printz` functions.